### PR TITLE
GEOIP_APP_ENDPOINT, "own_ip" removal and templates cosmetic changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ $ uwsgi --master --http 0.0.0.0:8888 --chdir /opt/geoip-flask/ --module app:app 
 
 ```
 $ docker pull supermasita/geoip-flask
-$ docker run -d --env GEOIP_APP_DOMAIN=example.com -p 8888:8888  -t supermasita/geoip-flask
+$ docker run -d --env GEOIP_APP_ENDPOINT=http://example.com:8888 -p 8888:8888  -t supermasita/geoip-flask
 ```
 
 Note that the Docker image runs uWSGI in the following way:
@@ -45,11 +45,11 @@ The following OS variables can be set to override `config.py`:
 * `GEOIP_APP_HOST` ("0.0.0.0")
 * `GEOIP_APP_PORT` ("8888")
 * `GEOIP_APP_DEBUG` (False)
-* `GEOIP_APP_DOMAIN` ("geoip.supermasita.com")
+* `GEOIP_APP_ENDPOINT` ("http://geoip.supermasita.com:8888")
 * `GEOIP_APP_TITLE` ("A service for MaxMind's GeoIP DB using Flask")
 * `GEOIP_APP_PROXY_IP_HEADER` ("X-Real-IP")
 
-If you are running a Docker image, you can use `docker run -e GEOIP_APP_DOMAIN=example.com ...`.
+If you are running a Docker image, you can use `docker run -e GEOIP_APP_ENDPOINT=http://example.com ...`.
 
 ## Getting updated Maxmind DB
 Due to changes in how Maxmind allows to download updated versions of their DBs, ATM there is no built in process to periodically update it. To do so you can rebuild the image passing `--build-arg LICENSE_KEY={your maxmind key}` or download an updated Docker image from [Dockerhub](https://hub.docker.com/r/supermasita/geoip-flask).

--- a/app.py
+++ b/app.py
@@ -1,6 +1,6 @@
 #!flask/bin/python
 from flask import Flask, jsonify, render_template, request
-from config import geo_db_location, app_host, app_port, app_debug, app_domain, app_title, app_proxy_ip_header
+from config import geo_db_location, app_host, app_port, app_debug, app_endpoint, app_title, app_proxy_ip_header
 
 
 import geoip2.database
@@ -35,10 +35,9 @@ def _get_ip(ip=None):
                  - "EXCEPTION", for any other exception
                 
     """
-    response = {'own_ip': False}
+    response = {}
     if ip is None:
         ip = _get_requester_ip()
-        response['own_ip'] = True
     response['ip'] = ip
     response['geoip_db_mtime'] = geoip_db_mtime 
     try:
@@ -63,12 +62,12 @@ def _get_ip(ip=None):
 
 @app.route('/', methods=['GET'])
 @app.route('/<string:ip>', methods=['GET'])
-def html_response(ip=None, own_ip=False):
+def html_response(ip=None):
     """Get data for IP and render HTML template
     """
     results = _get_ip(ip)
     return render_template("index.html", results=results,
-                           app_title=app_title, app_domain=app_domain)
+                           app_title=app_title, app_endpoint=app_endpoint)
 
 
 @app.route('/api/v1.0/ip/', methods=['GET'])

--- a/config.py
+++ b/config.py
@@ -9,8 +9,8 @@ app_port = os.getenv("GEOIP_APP_PORT", "8888")
 # Flask debug flag
 app_debug = os.getenv("GEOIP_APP_DEBUG", False)
 
-# Domain used in template anchors
-app_domain = os.getenv("GEOIP_APP_DOMAIN", "geoip.supermasita.com")
+# Domain used in template anchors - Must include scheme (http/https)
+app_endpoint = os.getenv("GEOIP_APP_ENDPOINT", "http://geoip.supermasita.com:8888")
 # HTML title for template
 app_title = os.getenv("GEOIP_APP_TITLE", "A service for MaxMind's GeoIP DB using Flask")
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,11 +1,11 @@
 # Run example:
-#  sudo docker run -d --env GEOIP_APP_DOMAIN=example.com -p 8888:8888  -t supermasita/geoip-flask
+#  sudo docker run -d --env GEOIP_APP_ENDPOINT=http://example.com:8888 -p 8888:8888  -t supermasita/geoip-flask
 # Build with:
 #  --build-arg LICENSE_KEY={your maxmind key}
 
 FROM ubuntu:20.04
 
-ENV UPDATED "2020-12-27"
+ENV UPDATED "2020-12-29"
 
 ARG LICENSE_KEY
 

--- a/templates/base.html
+++ b/templates/base.html
@@ -9,19 +9,16 @@
     <body style="margin:10px;">
         {% block content %}{% endblock %}
 	<hr>
-	<font style='font-size:75%;'>
-	<h5>Usage</h5>
+	<font style='font-size:70%;'>
+	<h5>How to use</h5>
 	<ul>
-		<li>See information of your IP: <a href="https://{{ app_domain }}/">https://{{ app_domain }}/</a></li>
-		<li>See information of IP 63.245.208.212: <a href="https://{{ app_domain }}/63.245.208.212">https://{{ app_domain }}/63.245.208.212</a></li>
-		<li>Get JSON with information of your IP: <a href="https://{{ app_domain }}/api/v1.0/ip/">https://{{ app_domain }}/api/v1.0/ip/</a></li>
-		<li>Get JSON with information of IP 63.245.208.212: <a href="https://{{ app_domain }}/api/v1.0/ip/63.245.208.212">https://{{ app_domain }}/api/v1.0/ip/63.245.208.212</a></li>
+		<li>See information of your IP: <a href="{{ app_endpoint }}/">{{ app_endpoint }}/</a></li>
+		<li>See information of IP 63.245.208.212: <a href="{{ app_endpoint }}/63.245.208.212">{{ app_endpoint }}/63.245.208.212</a></li>
+		<li>Get JSON with information of your IP: <a href="{{ app_endpoint }}/api/v1.0/ip/">{{ app_endpoint }}/api/v1.0/ip/</a></li>
+		<li>Get JSON with information of IP 63.245.208.212: <a href="{{ app_endpoint }}/api/v1.0/ip/63.245.208.212">{{ app_endpoint }}/api/v1.0/ip/63.245.208.212</a></li>
 	</ul>
-	<h5>Credits</h5>
-	<ul>
-		<li><a href="https://github.com/supermasita/geoip-flask">Github project</a></li>
-		<li>We use GeoLite2 data created by <a href="http://www.maxmind.com" target="_blank">MaxMind</a> (updated {{ results['geoip_DB_MTime'] }}).</li>
-	</ul>
+	<hr>
+	<p align="right"><code><a href="https://github.com/supermasita/geoip-flask">Github project</a> | We use GeoLite2 data created by <a href="http://www.maxmind.com" target="_blank">MaxMind</a> (<i>updated {{ results['geoip_db_mtime'] }}</i>)</code></p>
 	</font>
     </body>
 </html>

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,26 +1,30 @@
 {% extends "base.html" %}
 {% block content %}
-
-{% if results['traits'] %}
-{% if not results['registered_country'] or not results['country'] %}
-<i><font style='font-size:75%; background-color:#000; color:#fff;'>Ouch! This IP has very limited (or none) information in database</font></i>
-{% endif %}
-<ul>
-	<li>IP: <b>{{ results['traits']['ip_address'] }}</b> {% if results['own_ip'] == True %}<i>(this is your own IP)</i>{% endif %}</li>
-	{% if results['registered_country'] %}
-	<li>Country: {{ results['registered_country']['names']['en'] }} (<a href="https://www.geonames.org/countries/{{ results['registered_country']['iso_code'] }}/" target="_blank">{{ results['registered_country']['iso_code'] }}</a>)</li>
-	{% endif %}
-	{% if results['country'] %}
-	   <li>City: {% if results['city'] %}{{ results['city']['names']['en'] }}{% else %}N/A{% endif %}</li>
-	   <li>Continent: {{ results['continent']['names']['en'] }}</li>
-	   <li>Latitude: {{ results['location']['latitude'] }}</li>
-	   <li>Longitude: {{ results['location']['longitude'] }}</li>
-	   <li>Time zone: {{ results['location']['time_zone'] }}</li>
-	   <li><a href="https://www.openstreetmap.org/?mlat={{ results['location']['latitude'] }}&amp;mlon={{ results['location']['longitude'] }}#map={{ results['location']['latitude'] }}/{{ results['location']['longitude'] }}" target="_blank">See in map</a></li>
-	{% endif %}
-</ul>
-{% else %}
-{{ results['ip'] }} is not a valid public IP.
-{% endif %}
-
+   {%- if results['traits'] %}
+       {%- if not results['registered_country'] or not results['country'] %}
+          <div class="alert alert-warning">
+              <i><font style='font-size:75%; background-color:#000; color:#fff;'>Ouch! This IP has very limited (or no) information in database</font></i>
+          </div>
+       {%- endif %}
+       <div class="alert alert-success">
+           <ul>
+           	<li>IP: <b>{{ results['traits']['ip_address'] }}</b></li>
+           	{%- if results['registered_country'] %}
+           	<li>Country: {{ results['registered_country']['names']['en'] }} (<a href="https://www.geonames.org/countries/{{ results['registered_country']['iso_code'] }}/" target="_blank">{{ results['registered_country']['iso_code'] }}</a>)</li>
+           	{%- endif %}
+           	{%- if results['country'] %}
+           	   <li>City: {% if results['city'] %}{{ results['city']['names']['en'] }}{% else %}N/A{% endif %}</li>
+           	   <li>Continent: {{ results['continent']['names']['en'] }}</li>
+           	   <li>Latitude: {{ results['location']['latitude'] }}</li>
+           	   <li>Longitude: {{ results['location']['longitude'] }}</li>
+           	   <li>Time zone: {{ results['location']['time_zone'] }}</li>
+           	   <li><a href="https://www.openstreetmap.org/?mlat={{ results['location']['latitude'] }}&amp;mlon={{ results['location']['longitude'] }}#map={{ results['location']['latitude'] }}/{{ results['location']['longitude'] }}" target="_blank">See in map</a></li>
+           	{%- endif %}
+           </ul>
+       </div>
+   {%- else %}
+       <div class="alert alert-danger">
+           <b>{{ results['ip'] }}</b> is not a valid public IP. Is it an internal IP? Do you have a typo?
+       </div>
+   {%- endif %}
 {% endblock %}


### PR DESCRIPTION
- Replaced `GEOIP_APP_DOMAIN` with `GEOIP_APP_ENDPOINT`, which now should
also include scheme and port (if needed).
- Removed `own_ip` functionality (it just showed if the IP has not been
explicitly passed... meh)
- Some cosmetic changes in templates