### PR TITLE
Fix bug with uWSGI

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ $ python3 app.py
 #### Using UWSGI (example)
 
 ```
-$ uwsgi --master --http 0.0.0.0:8888 --chdir /opt/geoip-flask/ --module app:app --processes 4
+$ uwsgi --master --http 0.0.0.0:8888 --module app:app --processes 4
 ```
 
 #### Using the [Docker image](https://hub.docker.com/r/supermasita/geoip-flask)

--- a/templates/base.html
+++ b/templates/base.html
@@ -18,7 +18,7 @@
 		<li>Get JSON with information of IP 63.245.208.212: <a href="{{ app_endpoint }}/api/v1.0/ip/63.245.208.212">{{ app_endpoint }}/api/v1.0/ip/63.245.208.212</a></li>
 	</ul>
 	<hr>
-	<p align="right"><code><a href="https://github.com/supermasita/geoip-flask">Github project</a> | We use GeoLite2 data created by <a href="http://www.maxmind.com" target="_blank">MaxMind</a> (<i>updated {{ results['geoip_db_mtime'] }}</i>)</code></p>
+	<p align="right"><code><a href="https://github.com/supermasita/geoip-flask">Github project</a> | We use GeoLite2 data created by <a href="http://www.maxmind.com" target="_blank">MaxMind</a> (<i>DB mtime: {{ results['geoip_db_mtime'] }}</i>)</code></p>
 	</font>
     </body>
 </html>


### PR DESCRIPTION
Global variables had been moved into the `__main__` execution. This
worked correctly when using Flask but break with uWSGI (which instead
of `__main__` "sees" `app`).

Reorganized code and called `dbReader` using a `with` statement. This
needs to be reviewed in the future, to see if there is a way to reuse
the object, with the assumption that creating an object has a non
trivial overhead (might not be true).