### PR TITLE
Update docker image build

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -5,12 +5,12 @@
 
 FROM ubuntu:20.04
 
-ENV UPDATED "2020-12-29"
+ENV UPDATED "2020-12-30"
 
 ARG LICENSE_KEY
 
 RUN apt-get update \
-    && apt-get install -y git python3-pip curl unzip supervisor 
+    && apt-get install -y python3-pip curl unzip supervisor 
 
 RUN cd /opt/ \
     && curl https://codeload.github.com/supermasita/geoip-flask/zip/master -o master.zip \

--- a/docker/hooks/build
+++ b/docker/hooks/build
@@ -1,2 +1,2 @@
 #!/bin/bash
-docker build --build-arg LICENSE_KEY=$LICENSE_KEY .
+docker build --build-arg LICENSE_KEY=$LICENSE_KEY --tag "supermasita/geoip-flask" .


### PR DESCRIPTION
- Don't install `git` (not needed)
- Add `--tag` in hook, to avoid Docker Hub from erroring out with
  ```
  {u'message': u'An image does not exist locally with the tag: supermasita/geoip-flask'}
  ```