### PR TITLE
Fix LICENSE_KEY during Docker build

### DIFF
--- a/.github/workflows/docker-image-build.yml
+++ b/.github/workflows/docker-image-build.yml
@@ -22,7 +22,7 @@ jobs:
       run: |
         ls -l
         cd docker
-        docker build . --file Dockerfile --tag supermasita/geoip-flask:latest
+        docker build . --file Dockerfile --build-arg LICENSE_KEY=${{ secrets.LICENSE_KEY }} --tag supermasita/geoip-flask:latest
       
     - name: Docker Push
       run: docker push supermasita/geoip-flask

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -23,7 +23,7 @@ RUN cd /opt/geoip-flask \
 
 RUN mkdir /opt/geoip-flask/GeoLite2-City/
 
-RUN curl "https://download.maxmind.com/app/geoip_download?edition_id=GeoLite2-City&license_key=${{ secrets.LICENSE_KEY }}&suffix=tar.gz" \ 
+RUN curl "https://download.maxmind.com/app/geoip_download?edition_id=GeoLite2-City&license_key=${LICENSE_KEY}&suffix=tar.gz" \ 
     -o /opt/geoip-flask/GeoLite2-City/GeoLite2-City.tar.gz 
 
 RUN cd /opt/geoip-flask/GeoLite2-City \ 


### PR DESCRIPTION
- Reverts supermasita/geoip-flask#19
- Add `LICENSE_KEY` secret as build argument during docker execution